### PR TITLE
Add connection with Chrome DevTools inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Connect to chrome devtools inspector using the `inspector` node package.
 
 ## [0.1.3] - 2019-09-27
 ### Fixed

--- a/config/createWebpackConfig.ts
+++ b/config/createWebpackConfig.ts
@@ -133,7 +133,7 @@ const getBaseWebpackConfig = (options?: Options): Configuration => {
     mode: webpackMode,
     name: isServer ? 'server' : 'client',
     target: isServer ? 'node' : 'web',
-    devtool: dev && !isServer ? 'cheap-module-source-map' : false,
+    devtool: dev ? 'cheap-module-source-map' : false,
     context: paths.appPath,
     externals,
     entry: {

--- a/src/start-dev.ts
+++ b/src/start-dev.ts
@@ -1,4 +1,7 @@
+/* eslint-disable no-console */
 import express from 'express'
+import inspector from 'inspector'
+import chalk from 'chalk'
 
 import server from './index'
 import proxyMiddleware from './middlewares/proxy'
@@ -9,6 +12,25 @@ import { logStore } from './output/logger'
 const PORT = 3000
 
 const start = () => {
+  try {
+    inspector.open()
+    console.log(
+      chalk`
+{dim
+  {green Debugger started on ${inspector.url()}}
+}`.trim()
+    )
+  } catch (err) {
+    const errorStr = chalk`
+{dim
+  {red Could not establish a connection with the inspector}
+  {gray ${err}}
+}
+    `.trim()
+
+    console.error(errorStr)
+  }
+
   const app = express()
 
   proxyMiddleware.set(app)


### PR DESCRIPTION
add the connection when running the `dev` command.

![image](https://user-images.githubusercontent.com/10223856/65803307-9aac5b00-e154-11e9-999e-af5427a76143.png)