### PR TITLE
Add flag to build script to enable profiling in production

### DIFF
--- a/packages/react-app-server/cli/build.ts
+++ b/packages/react-app-server/cli/build.ts
@@ -30,13 +30,14 @@ process.on('unhandledRejection', (err) => {
 // Create the production build and print the deployment instructions.
 async function build(
   previousFileSizes: { root: string; sizes: Record<string, number> },
-  writeStatsJson = false
+  writeStatsJson = false,
+  profile = false
 ) {
   console.log('Creating an optimized production build...')
 
   const compiler = webpack([
-    await getBaseWebpackConfig(),
-    await getBaseWebpackConfig({ isServer: true }),
+    await getBaseWebpackConfig({ profile }),
+    await getBaseWebpackConfig({ isServer: true, profile }),
   ])
 
   const run = util.promisify(compiler.run)
@@ -116,6 +117,7 @@ export default function startBuild() {
   // Process CLI arguments
   const argv = process.argv.slice(3)
   const writeStatsJson = argv.indexOf('--stats') !== -1
+  const profile = argv.indexOf('--profile') !== -1
 
   // First, read the current file sizes in build directory.
   // This lets us display how much they changed later.
@@ -127,7 +129,7 @@ export default function startBuild() {
       // Merge with the public folder
       copyPublicFolder()
       // Start the webpack build
-      return build(previousFileSizes, writeStatsJson)
+      return build(previousFileSizes, writeStatsJson, profile)
     })
     .then(
       ({ stats, previousFileSizes, warnings }) => {

--- a/packages/react-app-server/config/createWebpackConfig.ts
+++ b/packages/react-app-server/config/createWebpackConfig.ts
@@ -41,7 +41,7 @@ const sassModuleRegex = /\.(scss|sass)$/
 const getBaseWebpackConfig = async (
   options?: Options
 ): Promise<Configuration> => {
-  const { isServer = false, dev = false } = options ?? {}
+  const { isServer = false, dev = false, profile = false } = options ?? {}
 
   // Get environment variables to inject into our app.
   const env = getClientEnvironment({ isServer })
@@ -281,6 +281,12 @@ const getBaseWebpackConfig = async (
         ...(!isServer
           ? {
               buffer: require.resolve('buffer'),
+            }
+          : null),
+        ...(!isServer && !dev && profile
+          ? {
+              'react-dom$': 'react-dom/profiling',
+              'scheduler/tracing': 'scheduler/tracing-profiling',
             }
           : null),
       },

--- a/packages/react-app-server/config/webpack/types.ts
+++ b/packages/react-app-server/config/webpack/types.ts
@@ -1,4 +1,5 @@
 export interface Options {
   isServer?: boolean
   dev?: boolean
+  profile?: boolean
 }


### PR DESCRIPTION
You can now run `rs build --profile` and it will use the react-dom version for profiling in PROD, as described in [this gist](https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977).