### PR TITLE
Implement granular chunks

### DIFF
--- a/packages/react-app-server/config/createWebpackConfig.ts
+++ b/packages/react-app-server/config/createWebpackConfig.ts
@@ -28,15 +28,15 @@ import { createOptimizationConfig } from './webpack/optimization'
 import RequireCacheHotReloaderPlugin from './webpack/plugins/RequireCacheHotReloaderPlugin'
 import SSRImportPlugin from './webpack/plugins/SSRImportPlugin'
 import RoutesManifestPlugin from './webpack/plugins/routes/RoutesManifestPlugin'
-import { getStyleLoaders } from './webpack/styles'
+import {
+  cssModuleRegex,
+  cssRegex,
+  getStyleLoaders,
+  sassModuleRegex,
+  sassRegex,
+} from './webpack/styles'
 import { Options } from './webpack/types'
 import { createWorkboxPlugin } from './webpack/workbox'
-
-// style files regexes
-const cssRegex = /\.global\.css$/
-const cssModuleRegex = /\.css$/
-const sassRegex = /\.global\.(scss|sass)$/
-const sassModuleRegex = /\.(scss|sass)$/
 
 const getBaseWebpackConfig = async (
   options?: Options
@@ -266,7 +266,10 @@ const getBaseWebpackConfig = async (
       libraryTarget: isServer ? 'commonjs2' : 'assign',
     },
     performance: { hints: false },
-    optimization: createOptimizationConfig({ dev, isServer }),
+    optimization: createOptimizationConfig({
+      dev,
+      isServer,
+    }),
     resolve: {
       modules: ['node_modules'].concat(
         process.env.NODE_PATH!.split(path.delimiter).filter(Boolean)
@@ -431,7 +434,7 @@ const getBaseWebpackConfig = async (
       // Even though require.cache is server only we have to clear assets from both compilations
       // This is because the client compilation generates the asset manifest that's used on the server side
       dev && new RequireCacheHotReloaderPlugin(),
-      !isServer && new RoutesManifestPlugin(),
+      !isServer && new RoutesManifestPlugin({ dev, isServer }),
       !isServer && hasServiceWorker && createWorkboxPlugin({ dev, isServer }),
       // Fix dynamic imports on server bundle
       isServer && new SSRImportPlugin(),

--- a/packages/react-app-server/config/webpack/optimization.ts
+++ b/packages/react-app-server/config/webpack/optimization.ts
@@ -1,15 +1,34 @@
+import crypto from 'crypto'
+import { sep } from 'path'
+
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin'
 // @ts-ignore: TODO: typings incompatible with webpack 5
 import TerserPlugin, { TerserPluginOptions } from 'terser-webpack-plugin'
-import { Configuration } from 'webpack'
+import { Chunk, Configuration, Module } from 'webpack'
 
 import { STATIC_CHUNKS_PATH, STATIC_RUNTIME_WEBPACK } from '../constants'
+import { appPath } from '../paths'
 import { Options as ArgOptions } from './types'
+
+const isModuleCSS = (module: Module): boolean => {
+  return (
+    // mini-css-extract-plugin
+    module.type === `css/mini-extract`
+  )
+}
+
+const BYTE = 1
+const KILOBYTE = 1000 * BYTE
+
+interface Options extends ArgOptions {
+  numberOfRoutes?: number
+}
 
 export const createOptimizationConfig = ({
   dev,
   isServer,
-}: ArgOptions): Configuration['optimization'] => {
+  numberOfRoutes = 0,
+}: Options): Required<Configuration>['optimization'] => {
   const terserPluginConfig: TerserPluginOptions = {
     parallel: true,
   }
@@ -28,7 +47,10 @@ export const createOptimizationConfig = ({
       defaultVendors: false,
       styles: {
         name: 'styles',
-        test: /.(sa|sc|c)ss$/,
+        test(module: Module) {
+          // TODO: do not include CSS modules
+          return isModuleCSS(module)
+        },
         chunks: 'all',
         enforce: true,
       },
@@ -54,14 +76,75 @@ export const createOptimizationConfig = ({
   ]
 
   splitChunks.chunks = 'all'
+
   splitChunks.cacheGroups = {
     ...(splitChunks.cacheGroups as Record<string, unknown>),
     react: {
-      name: `${STATIC_CHUNKS_PATH}/react`,
+      name: `${STATIC_CHUNKS_PATH}${sep}react`,
       chunks: 'all',
       test: /[\\/]node_modules[\\/](react|react-dom|react-is|scheduler)[\\/]/,
+      priority: 40,
+      enforce: true,
+    },
+    lib: {
+      test(module: Module) {
+        return (
+          !isModuleCSS(module) &&
+          module.size() > 160 * KILOBYTE &&
+          /node_modules[/\\]/.test(module.identifier())
+        )
+      },
+      name(module: Module) {
+        const hash = crypto.createHash('sha1')
+
+        if (!module.libIdent) {
+          throw new Error(
+            `Encountered unknown module type: ${module.type}. Please open an issue.`
+          )
+        }
+
+        hash.update(module.libIdent({ context: appPath }))
+
+        return (
+          STATIC_CHUNKS_PATH + sep + 'lib-' + hash.digest('hex').substring(0, 8)
+        )
+      },
+      priority: 30,
+      minChunks: 1,
+      reuseExistingChunk: true,
+    },
+    commons: {
+      name: STATIC_CHUNKS_PATH + sep + 'commons',
+      minChunks: Math.max(numberOfRoutes, 2),
+      priority: 20,
+    },
+    shared: {
+      test(module: Module) {
+        return !isModuleCSS(module)
+      },
+      name(_: Module, chunks: Chunk[]) {
+        return (
+          STATIC_CHUNKS_PATH +
+          sep +
+          'shared-' +
+          crypto
+            .createHash('sha1')
+            .update(
+              chunks.reduce((acc, chunk) => {
+                return acc + chunk.name
+              }, '')
+            )
+            .digest('hex')
+        )
+      },
+      priority: 10,
+      minChunks: 2,
+      reuseExistingChunk: true,
     },
   }
+
+  splitChunks.maxInitialRequests = 25
+  splitChunks.minSize = 20 * KILOBYTE
 
   config.splitChunks = splitChunks
 

--- a/packages/react-app-server/config/webpack/styles.ts
+++ b/packages/react-app-server/config/webpack/styles.ts
@@ -9,6 +9,12 @@ interface StyleOptions extends Options {
   loaders?: RuleSetUse[]
 }
 
+// style files regexes
+export const cssRegex = /\.global\.css$/
+export const cssModuleRegex = /\.css$/
+export const sassRegex = /\.global\.(scss|sass)$/
+export const sassModuleRegex = /\.(scss|sass)$/
+
 // common function to get style loaders
 export const getStyleLoaders = ({
   isServer = false,
@@ -26,6 +32,10 @@ export const getStyleLoaders = ({
         // Necessary for external CSS imports to work
         // https://github.com/facebook/create-react-app/issues/2677
         ident: 'postcss',
+        map: {
+          inline: false,
+          annotate: false,
+        },
         plugins: [
           require.resolve('postcss-flexbugs-fixes'),
           [


### PR DESCRIPTION
## Description

This PR is heavily inspired by the same strategies used in both Next.js and in Gatsby, and enables a more granular chunking strategy when building the PROD version of the app. This will decrease the number of duplicated code in chunks by creating multiple "commons" chunks, and bundling together the modules used in all routes simultaneously, and also creating a "framework" bundle (for stuff like React and ReactDOM). You can read more about it in [this web.dev blog post](https://web.dev/granular-chunking-nextjs/).

## Related

gatsbyjs/gatsby#22253
vercel/next.js#7696
