### PR TITLE
Update build directory name of react-app-server to lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,5 +122,4 @@ tags
 
 # End of https://www.gitignore.io/api/vim,node,macos
 
-dist
 lib

--- a/packages/react-app-server/bin/rs-bin.js
+++ b/packages/react-app-server/bin/rs-bin.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 // eslint-disable-next-line
 const path = require('path')
-require(path.join(__dirname, '../dist/bin/rs'))
+require(path.join(__dirname, '../lib/bin/rs'))

--- a/packages/react-app-server/config/createWebpackConfig.ts
+++ b/packages/react-app-server/config/createWebpackConfig.ts
@@ -179,7 +179,7 @@ const getBaseWebpackConfig = async (
             return callback()
           }
 
-          if (res.match(/react-app-server[/\\]dist[/\\]/)) {
+          if (res.match(/react-app-server[/\\]lib[/\\]/)) {
             return callback()
           }
 

--- a/packages/react-app-server/package.json
+++ b/packages/react-app-server/package.json
@@ -6,15 +6,15 @@
     "rs": "./bin/rs-bin.js"
   },
   "files": [
-    "dist",
+    "lib",
     "bin",
     "*.js",
     "*.d.ts"
   ],
   "scripts": {
-    "start": "cross-env NODE_ENV=development node dist/server/start-dev.js",
-    "start-prod": "cross-env NODE_ENV=production node dist/server/start.js",
-    "clean": "rimraf dist",
+    "start": "cross-env NODE_ENV=development node lib/server/start-dev.js",
+    "start-prod": "cross-env NODE_ENV=production node lib/server/start.js",
+    "clean": "rimraf lib",
     "ts": "tsc",
     "build": "run-s clean ts",
     "dev": "tsc --watch"

--- a/packages/react-app-server/tsconfig.json
+++ b/packages/react-app-server/tsconfig.json
@@ -8,9 +8,9 @@
     "moduleResolution": "node",
     "strict": true,
     "declaration": true,
-    "outDir": "dist",
+    "outDir": "lib",
     "allowJs": true,
     "skipLibCheck": true
   },
-  "exclude": ["dist/**/*", "./*.js", "./*.d.ts"]
+  "exclude": ["lib", "./*.js", "./*.d.ts"]
 }


### PR DESCRIPTION
This will make it consistent with `@app-server/components` and should be the "standard" build directory name for the packages in this monorepo.
