### PR TITLE
Fix global fetch polyfill causing build errors

### DIFF
--- a/packages/react-app-server/bin/rs.ts
+++ b/packages/react-app-server/bin/rs.ts
@@ -28,13 +28,7 @@ process.env.NODE_ENV = process.env.NODE_ENV || defaultEnv
 commands[command]()
 
 // @ts-ignore
-const { Request, Response, Headers } = require('minipass-fetch')
-const Body = require('minipass-fetch/lib/body')
-
-Object.assign(
-  global,
-  { Request, Response, Headers, Body },
-  {
-    fetch: require('make-fetch-happen'),
-  }
-)
+global.Body = require('minipass-fetch/lib/body')
+global.Request = require('minipass-fetch').Request
+global.Response = require('minipass-fetch').Response
+global.Headers = require('minipass-fetch').Headers

--- a/packages/react-app-server/server/defaultServer.tsx
+++ b/packages/react-app-server/server/defaultServer.tsx
@@ -1,6 +1,7 @@
 import * as fs from 'fs'
 import { IncomingMessage, ServerResponse } from 'http'
 import * as path from 'path'
+import { Writable } from 'stream'
 import { parse as parseUrl } from 'url'
 
 import { RootContext } from '@app-server/components'
@@ -23,6 +24,12 @@ import {
   isPreconditionFailure,
   requestContainsPrecondition,
 } from './utils'
+
+declare global {
+  const Body: {
+    writeToStream(stream: Writable, body: Body): void
+  }
+}
 
 const readJSON = (filePath: string) => {
   const file = fs.readFileSync(filePath)
@@ -243,6 +250,8 @@ export class DefaultServer {
         Array.isArray(value) ? value : value?.toString(),
       ]) as Array<[string, string]>,
     })
+
+    global.fetch = require('make-fetch-happen')
 
     const handleRequest = await this.getAppRequestHandler()
 


### PR DESCRIPTION
## Description

When building an app that uses the global fetch polyfill, the following error was being emitted during the build, and this PR fixes that

![image](https://user-images.githubusercontent.com/10223856/98468678-57774500-21ba-11eb-933a-713cb2e5b428.png)

You can find more details about the error above in the linked issue below.

## Related

mozilla/source-map#349