### PR TITLE
Fix error in build when import dependency module was concatenated

### DIFF
--- a/packages/react-app-server/config/webpack/plugins/routes/RouteImportDependencyTemplate.ts
+++ b/packages/react-app-server/config/webpack/plugins/routes/RouteImportDependencyTemplate.ts
@@ -35,7 +35,7 @@ export default class RouteImportDependencyTemplate extends ImportDependency.Temp
       return super.apply(dependency, source, templateContext)
     }
 
-    const module = moduleGraph.getModule(dependency)
+    const module = moduleGraph.getResolvedModule(dependency)
     const userRequest = (module as NormalModule).userRequest
     const moduleId =
       '.' +

--- a/packages/react-app-server/config/webpack/plugins/routes/RouteModuleIdCollectorImportDependencyTemplate.ts
+++ b/packages/react-app-server/config/webpack/plugins/routes/RouteModuleIdCollectorImportDependencyTemplate.ts
@@ -36,12 +36,12 @@ export default class RouteModuleIdCollectorImportDependencyTemplate extends Impo
       return
     }
 
-    const module = moduleGraph.getModule(dependency)
+    const module = moduleGraph.getResolvedModule(dependency)
     const userRequest = (module as NormalModule).userRequest
     const modulePath =
       '.' + path.sep + path.relative(this.compilerContext, userRequest)
 
-    const moduleId = chunkGraph.getModuleId(module)
+    const moduleId = chunkGraph.getModuleId(moduleGraph.getModule(dependency))
 
     this.routeImportModuleIdMap[modulePath] = moduleId
   }

--- a/packages/react-app-server/config/webpack/plugins/routes/RouteModuleIdCollectorImportDependencyTemplate.ts
+++ b/packages/react-app-server/config/webpack/plugins/routes/RouteModuleIdCollectorImportDependencyTemplate.ts
@@ -12,7 +12,7 @@ export default class RouteModuleIdCollectorImportDependencyTemplate extends Impo
   private compilerContext
 
   constructor(
-    routeImportModuleIdMap: Record<string, string | number>,
+    routeImportModuleIdMap: Map<string, string | number>,
     compilerContext: string
   ) {
     super()
@@ -43,6 +43,6 @@ export default class RouteModuleIdCollectorImportDependencyTemplate extends Impo
 
     const moduleId = chunkGraph.getModuleId(moduleGraph.getModule(dependency))
 
-    this.routeImportModuleIdMap[modulePath] = moduleId
+    this.routeImportModuleIdMap.set(modulePath, moduleId)
   }
 }

--- a/packages/react-app-server/config/webpack/plugins/routes/utils.ts
+++ b/packages/react-app-server/config/webpack/plugins/routes/utils.ts
@@ -37,12 +37,12 @@ export const parseRoutesAndAssets = (
   mainAssets: string[],
   routeComponentsAssets: Record<string, string[]>,
   routes: RouteAssetComponent[],
-  routeModuleIdMap: Record<string, string | number>
+  routeModuleIdMap: Map<string, string | number>
 ) => {
   const parseRouteComponents = (
     route: RouteAssetComponent
   ): RouteWithAssets => {
-    const moduleId = routeModuleIdMap[route.component()]
+    const moduleId = routeModuleIdMap.get(route.component())!
 
     const routeWithComponents: RouteWithAssets = {
       caseSensitive: route.caseSensitive,


### PR DESCRIPTION
## Description

This PR fixes the following error when running `rs build`

![image](https://user-images.githubusercontent.com/10223856/98469461-8c859680-21be-11eb-9d23-6ac707e327b9.png)

The cause for this is in the custom import dependency templates, where we'd run `moduleGraph.getModule` for a dependency, and instead of it returning a `NormalModule` as it would in development, it returned a `ConcatenatedModule` (for optimization reasons), and this type of module does not have a `userRequest` property (which we use to get the filename of the import dependency). By changing the call from `moduleGraph.getModule` to `moduleGraph.getResolvedModule` we are guaranteed to always get the resolved module for that dependency, which always is a `NormalModule`.