### PR TITLE
Update logs of build server referencing dev server

### DIFF
--- a/packages/cli/src/output/logger.ts
+++ b/packages/cli/src/output/logger.ts
@@ -52,8 +52,8 @@ logStore.subscribe((state) => {
   }
 
   if (state.bootstrap === true) {
-    Log.wait('starting the development server')
-    Log.info(`build server ready on http://localhost:${state.port}`)
+    Log.wait('starting the build server')
+    Log.info(`build server listening on http://localhost:${state.port}`)
     return
   }
 


### PR DESCRIPTION
The "development server" is now under the user's ownership, the server spinned up by `@app-server/cli` should be referenced as a "build server".
