### PR TITLE
Fix asset modules filenames in client build

### DIFF
--- a/packages/cli/src/config/constants.ts
+++ b/packages/cli/src/config/constants.ts
@@ -6,6 +6,7 @@ export const STATIC_WEBPACK_PATH = path.join(STATIC_FOLDER, 'webpack')
 export const STATIC_CHUNKS_PATH = path.join(STATIC_FOLDER, 'chunks')
 export const STATIC_MEDIA_PATH = path.join(STATIC_FOLDER, 'media')
 export const STATIC_ENTRYPOINTS_PATH = path.join(STATIC_FOLDER, 'entrypoints')
+export const STATIC_ASSETS_PATH = path.join(STATIC_FOLDER, 'assets')
 
 export const STATIC_RUNTIME_MAIN = path.join(STATIC_RUNTIME_PATH, 'main')
 export const STATIC_RUNTIME_WEBPACK = path.join(STATIC_RUNTIME_PATH, 'webpack')

--- a/packages/cli/src/config/createWebpackConfig.ts
+++ b/packages/cli/src/config/createWebpackConfig.ts
@@ -15,6 +15,7 @@ import fileExists from '../utils/fileExists'
 import { filterBoolean } from '../utils/filterBoolean'
 import resolveRequest from '../utils/resolveRequest'
 import {
+  STATIC_ASSETS_PATH,
   STATIC_CHUNKS_PATH,
   STATIC_ENTRYPOINTS_ROUTES,
   STATIC_MEDIA_PATH,
@@ -268,6 +269,25 @@ const getBaseWebpackConfig = async (
       chunkFilename: isServer
         ? `${chunkFilename}.js`
         : `${STATIC_CHUNKS_PATH}/${chunkFilename}.js`,
+      assetModuleFilename: isServer
+        ? '[hash][ext][query]'
+        : (pathData) => {
+            const ext = pathData.filename
+              ?.split('?')[0]
+              .match(
+                new RegExp(
+                  `\\.(${
+                    useTypescript
+                      ? paths.typescriptFileExtensions.join('|') + '|'
+                      : ''
+                  }${paths.moduleFileExtensions.join('|')})$`
+                )
+              )
+              ? '.js'
+              : '[ext]'
+
+            return `${STATIC_ASSETS_PATH}/[hash]${ext}[query]`
+          },
       hotUpdateMainFilename: `${STATIC_WEBPACK_PATH}/[fullhash].hot-update.json`,
       hotUpdateChunkFilename: `${STATIC_WEBPACK_PATH}/[id].[fullhash].hot-update.js`,
       devtoolModuleFilenameTemplate: (info: any) =>


### PR DESCRIPTION
These files were being generated in the root of the build directory, and when the client requested them from the browser we would end up serving a 404 because we only look inside the `static` folder of the build dir or in subdirectories of that.
