### PR TITLE
Add styles chunking to production build only

### DIFF
--- a/packages/cli/src/config/webpack/optimization.ts
+++ b/packages/cli/src/config/webpack/optimization.ts
@@ -49,15 +49,6 @@ export const createOptimizationConfig = ({
     cacheGroups: {
       default: false,
       defaultVendors: false,
-      styles: {
-        name: 'styles',
-        test(module: Module) {
-          // TODO: do not include CSS modules
-          return isModuleCSS(module)
-        },
-        chunks: 'all',
-        enforce: true,
-      },
     },
   }
 
@@ -145,6 +136,15 @@ export const createOptimizationConfig = ({
       priority: 10,
       minChunks: 2,
       reuseExistingChunk: true,
+    },
+    styles: {
+      name: 'styles',
+      test(module: Module) {
+        // TODO: do not include CSS modules
+        return isModuleCSS(module)
+      },
+      chunks: 'all',
+      enforce: true,
     },
   }
 


### PR DESCRIPTION
We will only group all the styles for the production build only, as in development it is fine to keep them separated.
