### PR TITLE
Add support for passing props to route components

### DIFF
--- a/examples/routes/src/OtherPage.jsx
+++ b/examples/routes/src/OtherPage.jsx
@@ -2,10 +2,10 @@ import { Outlet } from 'react-router'
 
 import InternalLink from './InternalLink'
 
-const OtherPage = () => {
+const OtherPage = ({ name }) => {
   return (
     <div>
-      <p>Welcome to the other page!</p>
+      <p>Welcome to the other page, {name}!</p>
       <InternalLink to="/">Go back</InternalLink>
       <Outlet />
     </div>

--- a/examples/routes/src/routes.js
+++ b/examples/routes/src/routes.js
@@ -6,6 +6,9 @@ export default [
   {
     component: () => import('./OtherPage'),
     path: '/other-page',
+    props: {
+      name: 'Jon',
+    },
     children: [
       {
         component: () => import('./OtherPageChildren'),

--- a/packages/cli/src/config/webpack/plugins/routes/utils.ts
+++ b/packages/cli/src/config/webpack/plugins/routes/utils.ts
@@ -21,11 +21,13 @@ export type RouteAssetComponent = {
   component: () => string
   path: string
   children?: RouteAssetComponent[]
+  props?: Record<string, unknown>
 }
 
 export type RouteWithAssets = {
   caseSensitive?: boolean
   assets: string[]
+  props?: Record<string, unknown>
   componentName: string | number
   path: string
   children?: RouteWithAssets[]
@@ -50,6 +52,7 @@ export const parseRoutesAndAssets = (
       assets: routeComponentsAssets[moduleId],
       componentName: moduleId,
       children: undefined,
+      props: route.props,
     }
 
     if (route.children) {

--- a/packages/components/src/RootBrowser.tsx
+++ b/packages/components/src/RootBrowser.tsx
@@ -40,7 +40,7 @@ const parseRouteMatch = (
   return [
     {
       ...route,
-      element: <Component />,
+      element: <Component {...route.props} />,
       children: routes,
     },
   ]

--- a/packages/components/src/RootContext.tsx
+++ b/packages/components/src/RootContext.tsx
@@ -4,6 +4,7 @@ import { RouteMatch, RouteObject } from 'react-router'
 export type RouteObjectWithKey = RouteObject & {
   key: number
   children?: RouteObjectWithKey[]
+  props?: Record<string, unknown>
 }
 
 export type RouteMatchWithKey = RouteMatch & { route: RouteObjectWithKey }

--- a/packages/react-app-server/utils/routes.ts
+++ b/packages/react-app-server/utils/routes.ts
@@ -11,6 +11,7 @@ export type RoutePromiseComponent = {
   >
   path: string
   children?: RoutePromiseComponent[]
+  props?: Record<string, unknown>
 }
 
 export type RouteObjectWithAssets = RouteObject & {
@@ -39,7 +40,8 @@ export const mergeRouteAssetsAndRoutes = (
         ...route,
         caseSensitive: route.caseSensitive === true,
         element: React.createElement(
-          await route.component().then(interopDefault)
+          await route.component().then(interopDefault),
+          route.props
         ),
         assets: routesManifestRoutes[index].assets ?? [],
         componentName: routesManifestRoutes[index].componentName,


### PR DESCRIPTION
## Description

With this PR, you can now pass in any (primitive) prop value to the route component! The syntax is as follow:

```js
// src/routes.js
export default [
  {
    component: () => import('./MyComponent'),
    path: '/',
    props: {
      name: 'Jon',
      shouldDisplayName: true,
      userId: 5,
    }
  }
]
```
