### PR TITLE
Update filename convention for CSS modules

### DIFF
--- a/packages/casterly/src/config/createWebpackConfig.ts
+++ b/packages/casterly/src/config/createWebpackConfig.ts
@@ -34,10 +34,10 @@ import {
 } from './webpack/plugins/RoutesManifestPlugin'
 import SSRImportPlugin from './webpack/plugins/SSRImportPlugin'
 import {
-  cssGlobalRegex,
+  cssModuleRegex,
   cssRegex,
   getStyleLoaders,
-  sassGlobalRegex,
+  sassModuleRegex,
   sassRegex,
 } from './webpack/styles'
 import type { Options } from './webpack/types'
@@ -268,37 +268,27 @@ const getBaseWebpackConfig = async (
 
   const cssRules = [
     {
-      test: cssGlobalRegex,
+      test: cssRegex,
+      exclude: [cssModuleRegex],
       use: cssConfig,
       compiler: not(isRouteManifestChildCompiler),
     },
     {
-      test: cssRegex,
-      exclude: [cssGlobalRegex, /node_modules/],
+      test: cssModuleRegex,
+      exclude: [/node_modules/],
       use: cssModuleConfig,
       compiler: not(isRouteManifestChildCompiler),
     },
     {
-      test: cssRegex,
-      include: [{ not: [paths.appSrc] }],
-      use: cssConfig,
-      compiler: not(isRouteManifestChildCompiler),
-    },
-    {
-      test: sassGlobalRegex,
+      test: sassRegex,
+      exclude: [sassModuleRegex],
       use: sassConfig,
       compiler: not(isRouteManifestChildCompiler),
     },
     {
-      test: sassRegex,
-      exclude: [sassGlobalRegex, /node_modules/],
+      test: sassModuleRegex,
+      exclude: [/node_modules/],
       use: sassModuleConfig,
-      compiler: not(isRouteManifestChildCompiler),
-    },
-    {
-      test: sassRegex,
-      include: [{ not: [paths.appSrc] }],
-      use: sassConfig,
       compiler: not(isRouteManifestChildCompiler),
     },
     {

--- a/packages/casterly/src/config/webpack/styles.ts
+++ b/packages/casterly/src/config/webpack/styles.ts
@@ -11,10 +11,10 @@ interface StyleOptions extends Options {
 }
 
 // style files regexes
-export const cssGlobalRegex = /\.global\.css$/
 export const cssRegex = /\.css$/
-export const sassGlobalRegex = /\.global\.(scss|sass)$/
+export const cssModuleRegex = /\.module\.css$/
 export const sassRegex = /\.(scss|sass)$/
+export const sassModuleRegex = /\.module\.(scss|sass)$/
 
 // common function to get style loaders
 export const getStyleLoaders = ({

--- a/test/integration/development/src/css.css
+++ b/test/integration/development/src/css.css
@@ -1,0 +1,3 @@
+.blue {
+  color: blue;
+}

--- a/test/integration/development/src/css.js
+++ b/test/integration/development/src/css.js
@@ -1,0 +1,11 @@
+import styles from './css.module.css'
+import './css.css'
+
+export default function CssPage() {
+  return (
+    <div>
+      <p className={styles.red}>i should be red</p>
+      <span className="blue">and I should be blue</span>
+    </div>
+  )
+}

--- a/test/integration/development/src/css.module.css
+++ b/test/integration/development/src/css.module.css
@@ -1,0 +1,3 @@
+.red {
+  color: red;
+}

--- a/test/integration/development/src/routes.js
+++ b/test/integration/development/src/routes.js
@@ -11,4 +11,8 @@ export default [
     path: '/back-link',
     component: () => import('./back-link'),
   },
+  {
+    path: '/css',
+    component: () => import('./css'),
+  },
 ]

--- a/test/integration/development/test/css.test.ts
+++ b/test/integration/development/test/css.test.ts
@@ -1,0 +1,40 @@
+import type { Browser, Page } from 'puppeteer'
+import puppeteer from 'puppeteer'
+
+const port = 3000
+
+describe('Hello World', () => {
+  let browser: Browser
+  let page: Page
+
+  beforeEach(async () => {
+    browser = await puppeteer.launch()
+    page = await browser.newPage()
+  })
+
+  afterEach(async () => {
+    await browser.close()
+  })
+
+  it('should load css files correctly', async () => {
+    await page.goto(`http://localhost:${port}/css`, {
+      waitUntil: 'networkidle2',
+    })
+
+    await expect(
+      page.evaluate(() => {
+        return window
+          .getComputedStyle(document.querySelector('.blue'))
+          .getPropertyValue('color')
+      })
+    ).resolves.toBe('rgb(0, 0, 255)')
+
+    await expect(
+      page.evaluate(() => {
+        return window
+          .getComputedStyle(document.querySelector('p'))
+          .getPropertyValue('color')
+      })
+    ).resolves.toBe('rgb(255, 0, 0)')
+  })
+})


### PR DESCRIPTION
From now on, to use css modules the file must be named with `.module.css`. All other CSS files will be treated as global CSS.

Resolves #472
