### PR TITLE
Fix react-router being bundled in server build

### DIFF
--- a/packages/casterly/src/config/createWebpackConfig.ts
+++ b/packages/casterly/src/config/createWebpackConfig.ts
@@ -362,12 +362,13 @@ const getBaseWebpackConfig = async (
       (process.platform === 'win32' && path.win32.isAbsolute(request))
 
     if (!isLocal) {
-      if (/^(?:react(?:$|\/))/.test(request)) {
+      if (
+        /^(?:(?:react-router|react-router-dom)|react(?:$|\/))/.test(request)
+      ) {
         return `commonjs ${request}`
       }
 
-      const notExternalModules =
-        /^(?:(?:(?:react-router|react-router-dom)(\/.*)?)|string-hash$)/
+      const notExternalModules = /^(?:string-hash$)/
 
       if (notExternalModules.test(request)) {
         return

--- a/packages/components/src/RootBrowser.tsx
+++ b/packages/components/src/RootBrowser.tsx
@@ -77,7 +77,9 @@ const mergeRoutes = (
     routes.push(newRoute)
   })
 
-  return routes.sort((routeA, routeB) => routeA.key - routeB.key)
+  return routes.sort((routeA, routeB) => {
+    return routeA.key - routeB.key
+  })
 }
 
 const addScript = (scriptAsset: string) => {

--- a/test/integration/production/src/index.jsx
+++ b/test/integration/production/src/index.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 export default function IndexPage() {
   return (
     <div>
+      <p id="index-header">Index page</p>
       <p>Links</p>
       <ul>
         <li>

--- a/test/integration/production/test/not-found.test.ts
+++ b/test/integration/production/test/not-found.test.ts
@@ -56,4 +56,16 @@ describe('Not found', () => {
     expect(reloadResponse.status()).toBe(404)
     await expect(page.content()).resolves.toMatch('you did not found me 😜')
   })
+
+  it('should be able to navigate away from not found page', async () => {
+    await page.goto(`http://localhost:${port}/unexistent-route`, {
+      waitUntil: 'networkidle2',
+    })
+
+    await Promise.all([page.waitForNavigation(), page.click('a')])
+
+    await page.waitForSelector('#index-header')
+
+    await expect(page.content()).resolves.toMatch('Index page')
+  })
 })


### PR DESCRIPTION
This caused issues in some situations where RR context wasn't being found.
